### PR TITLE
🔧 chore(lint-staged): Simplify pre-commit hook commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,9 +72,8 @@
   ],
   "lint-staged": {
     "**/*.{js,ts}": [
-      "npm run lint:fix-file",
-      "npm run format:fix-file",
-      "npm run types:check-file",
+      "eslint --fix",
+      "prettier --write",
       "npm run test:file"
     ]
   }


### PR DESCRIPTION
This commit refactors the `lint-staged` configuration to call ESLint and Prettier directly instead of using npm script wrappers. This simplification makes the pre-commit process slightly faster by reducing the overhead of npm script execution.

Additionally, the `types:check-file` step has been removed from the pre-commit hook to improve performance, as per-file TypeScript checking can be slow. Type checking will be handled by the CI pipeline to ensure type safety across the entire project.